### PR TITLE
Fix illegal VHDL in csr_pkg.vhd

### DIFF
--- a/src/csr_pkg.vhd
+++ b/src/csr_pkg.vhd
@@ -15,7 +15,7 @@ package csr_pkg is
         imm         : word;
         system_type : system_type_t;
         valid  :  std_logic;  -- '1' if this was a valid cycle that the core was executing
-        instret : in  std_logic;  -- '1' for instruction retired this cycle
+        instret : std_logic;  -- '1' for instruction retired this cycle
 
     end record csr_in_t;
     


### PR DESCRIPTION
It is not legal VHDL to have a port mode in a record.
I have developed a VHDL-parser and language server (https://github.com/kraigher/rust_hdl/) and was using you repo as a test when I found this error. 
The parser can process all VHDL files in your repo in 100 ms.